### PR TITLE
updated mariadb client lib and bioconductor

### DIFF
--- a/rstudio_shiny_inDocker/Dockerfile.R
+++ b/rstudio_shiny_inDocker/Dockerfile.R
@@ -8,11 +8,11 @@ RUN apt-get update -qq && apt-get -y --no-install-recommends install \
   libcairo2-dev \
   libsqlite3-dev \
   libmariadbd-dev \
-  libmariadb-client-lgpl-dev \
+  libmariadbclient-dev \
   libpq-dev \
   libssh2-1-dev \
   unixodbc-dev \
-  && R -e "source('https://bioconductor.org/biocLite.R')" \
+  && R -e "install.packages(\"BiocManager\")" \
   && install2.r --error \
     --deps TRUE \
     shiny \


### PR DESCRIPTION
If one uses the latest rocker/rstudio image the changes introduced by this pull request are needed. The Ubuntu version and Bioconductor have chnaged in the time elapsed since originally published.